### PR TITLE
Added cluster name to output

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -10,6 +10,11 @@ output "eks_cluster_id" {
   description = "Amazon EKS Cluster Name"
   value       = module.aws_eks.cluster_id
 }
+  
+output "eks_cluster_name" {
+  description = "Amazon EKS Cluster Name"
+  value       = module.aws_eks.cluster_name
+}
 
 output "eks_cluster_certificate_authority_data" {
   description = "Base64 encoded certificate data required to communicate with the cluster"


### PR DESCRIPTION

### What does this PR do?

added cluster name to output


### Motivation

Sometimes you want to refer to the cluster name.
For example, creating .kubeconfig files and tagging various resources.
In such a case, a cluster name is necessary.

<!-- What inspired you to submit this pull request? -->
- Resolves #<issue-number>

### More

- [] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
